### PR TITLE
Pass reader instead of file

### DIFF
--- a/config/my_desktop.yml
+++ b/config/my_desktop.yml
@@ -11,6 +11,7 @@ settings:
   timeout: 1
   xpos: 3335
   ypos: 0
+  mod_top: 1
 
 ui:
   - text: SYSTEM

--- a/config/my_desktop.yml
+++ b/config/my_desktop.yml
@@ -11,7 +11,7 @@ settings:
   timeout: 1
   xpos: 3335
   ypos: 0
-  mod_top: 1
+  # mod_top: 1
 
 ui:
   - text: SYSTEM

--- a/src/deets.rs
+++ b/src/deets.rs
@@ -252,7 +252,7 @@ fn get_ps_from_proc(mem_used: f64) -> Vec<PsInfo> {
                         Err(_) => continue,
                     }
 
-                    match try_exact_match_strings_from_file(reader, &vec!["Name", "VmRSS"], Some(_hack)) {
+                    match try_exact_match_strings_from_reader(reader, &vec!["Name", "VmRSS"], Some(_hack)) {
                         Ok(s)  => { s },
                         Err(_) => {
                             proc_files_map.remove(pid);

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -17,7 +17,7 @@ pub fn get_match_strings_from_path(path: &str, filters: &Vec<&str>) -> Vec<Strin
     }
 }
 
-pub fn try_exact_match_strings_from_file(reader: &mut BufReader<File>, filters: &Vec<&str>, hack: Option<fn(&i32, &str) -> u8>) -> Result<Vec<String>, std::io::Error> {
+pub fn try_exact_match_strings_from_reader(reader: &mut BufReader<File>, filters: &Vec<&str>, hack: Option<fn(&i32, &str) -> u8>) -> Result<Vec<String>, std::io::Error> {
     let filter_count = filters.len() - 1;
     let mut count = 0;
     let mut lines_vec = Vec::new();

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -17,10 +17,9 @@ pub fn get_match_strings_from_path(path: &str, filters: &Vec<&str>) -> Vec<Strin
     }
 }
 
-pub fn try_exact_match_strings_from_file(file: &mut File, filters: &Vec<&str>, hack: Option<fn(&i32, &str) -> u8>) -> Result<Vec<String>, std::io::Error> {
+pub fn try_exact_match_strings_from_file(reader: &mut BufReader<File>, filters: &Vec<&str>, hack: Option<fn(&i32, &str) -> u8>) -> Result<Vec<String>, std::io::Error> {
     let filter_count = filters.len() - 1;
     let mut count = 0;
-    let mut reader = BufReader::new(file);
     let mut lines_vec = Vec::new();
     let mut line_num = -1;
 

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -22,9 +22,10 @@ pub fn try_exact_match_strings_from_file(reader: &mut BufReader<File>, filters: 
     let mut count = 0;
     let mut lines_vec = Vec::new();
     let mut line_num = -1;
+    let mut line = String::new();
 
     loop {
-        let mut line = String::new();
+        line.clear();
         match reader.read_line(&mut line) {
             Ok(0)  => return Ok(lines_vec),
             Err(e) => return Err(e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,12 +329,12 @@ fn update_ui(config: &Yaml,
     }
 
     let timeout = config["timeout"].as_i64().unwrap_or(1);
-    let mod_top = config["skip_top"].as_i64().unwrap_or(2) as u64;
-    let mod_fs  = config["skip_fs"].as_i64().unwrap_or(2)  as u64;
+    let mod_top = config["mod_top"].as_i64().unwrap_or(2) as u64;
+    let mod_fs  = config["mod_fs"].as_i64().unwrap_or(2)  as u64;
 
     let update = move || {
         let mut frame_counter = FRAME_COUNT.lock().unwrap();
-        let mut frame_cache = deets::get_frame_cache(*frame_counter % 2 == 0);
+        let mut frame_cache = deets::get_frame_cache(*frame_counter % mod_top == 0);
         let cpu_mhz_vec = deets::get_cpu_mhz();
         let cpu_mhz_vec_len = cpu_mhz_vec.len();
 


### PR DESCRIPTION
Slight speed up of proc usage code:
* Cache and pass in the BufReader instead of the file so there is no excessive BufRead::new()
* Allocate String buffer outside of the read_line loop (still have to clear() it each iteration)

Very marginally faster.